### PR TITLE
Use append instead of store with multiple values

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,10 +39,10 @@ To install pytest-variables::
 Specifying variables
 --------------------
 
-Use the `--variables` command line option to specify one or more paths to JSON
-files containing your variables::
+Use the `--variables` command line option one or more times to specify paths to
+JSON files containing your variables::
 
-  py.test --variables foo.json bar.json
+  py.test --variables foo.json --variables bar.json
 
 If multiple files are specified then they will be applied in the order they
 appear on the command line. When duplicates are encountered, the last

--- a/pytest_variables.py
+++ b/pytest_variables.py
@@ -11,10 +11,9 @@ def pytest_addoption(parser):
     group = parser.getgroup('debugconfig')
     group.addoption(
         '--variables',
-        action='store',
+        action='append',
         default=[],
         metavar='path',
-        nargs='+',
         help='path to test variables JSON file.')
 
 

--- a/test_variables.py
+++ b/test_variables.py
@@ -6,10 +6,11 @@ pytest_plugins = "pytester",
 
 
 def run(testdir, variables=['{"foo":"bar"}']):
-    paths = []
+    args = []
     for i, v in enumerate(variables):
-        paths.append(testdir.makefile('{0}.json'.format(i), v))
-    return testdir.runpytest('--variables', *paths)
+        args.append('--variables')
+        args.append(testdir.makefile('{0}.json'.format(i), v))
+    return testdir.runpytest(*args)
 
 
 class TestVariables:


### PR DESCRIPTION
This avoids an issue when the --variables argument is the last item before the test path, which causes the test path to be mistreated as a variables file.

Pinging @bobsilverberg for review.