### PR TITLE
Add docstring to fixture to clean up output from py.test --fixtures

### DIFF
--- a/pytest_variables.py
+++ b/pytest_variables.py
@@ -19,6 +19,7 @@ def pytest_addoption(parser):
 
 @pytest.fixture(scope='session')
 def variables(request):
+    """Provide test variables from a JSON file"""
     data = {}
     for path in request.config.getoption('variables'):
         with open(path) as f:


### PR DESCRIPTION
Adding a short docstring to the variables fixture. This prevents a red warning in the output of `py.test --fixtures`.
